### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,12 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install lxml deps
-      run: |
-        sudo cp /etc/apt/sources.list /etc/apt/sources.list~
-        sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-        sudo apt-get update
-        sudo apt-get build-dep python3-lxml
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "spotipy==2.13.0",
     "requests==2.24.0",
     "youtube_title_parse==1.0.0",
+    "lxml==4.5.2",
     "beautifulsoup4==4.9.1",
     "google_api_python_client==1.10.0",
     "pytest==6.0.1",


### PR DESCRIPTION
This should fix issue #24 -- installing `python3-lxml` does nothing as it installs it for system interpreter but that doesn't seem to be the interpreter that runs the tests (running `python -c 'import lxml'` produces an import error). As `lxml` is optional dependency of `bs4` and it seems to be used in the app it makes sense to add it in `install_requires`.